### PR TITLE
Update notice file generation actions

### DIFF
--- a/.github/workflows/notice-generation.yml
+++ b/.github/workflows/notice-generation.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository and submodules
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           submodules: recursive
       - name: Install stable toolchain


### PR DESCRIPTION
We were seeing errors about deprecated GitHub actions being used.  The fix is to use the action "actions/checkout@v3" rather than "actions/checkout@v2".

See: https://stackoverflow.com/questions/75061837/github-actions-node-js-12-actions-are-deprecated-although-i-upgraded-everyt