### PR TITLE
adding IBEJI_HOME env var for loading the invehicle digital twin config file

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,8 +219,10 @@ Make sure that you replace "{repo-root-dir}" with the repository root directory 
 ---- provider_settings.yaml ----<br>
 `provider_authority: "0.0.0.0:4010"`<br>
 `invehicle_digital_twin_uri: "http://0.0.0.0:5010"`<br><br>
-1. In the top window, run:<br><br>
+1. In the top window, run (config files will be loaded from the current working directory):<br><br>
 `./invehicle-digital-twin`<br>
+Use the `IBEJI_HOME` env var to load configuration files from a specific directory: <br>
+`IBEJI_HOME=/etc/ibeji ./invehicle-digital-twin`<br>
 1. In the middle window, run:<br><br>
 `./seat-massager-provider`<br>
 1. In the bottom window, run:<br><br>

--- a/README.md
+++ b/README.md
@@ -221,7 +221,7 @@ Make sure that you replace "{repo-root-dir}" with the repository root directory 
 `invehicle_digital_twin_uri: "http://0.0.0.0:5010"`<br><br>
 1. In the top window, run (config files will be loaded from the current working directory):<br><br>
 `./invehicle-digital-twin`<br>
-Use the `IBEJI_HOME` env var to load configuration files from a specific directory: <br>
+Use the `IBEJI_HOME` environment variable to load configuration files from a specific directory: <br>
 `IBEJI_HOME=/etc/ibeji ./invehicle-digital-twin`<br>
 1. In the middle window, run:<br><br>
 `./seat-massager-provider`<br>

--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ The demos use config files and we have provided a templated version of each conf
 Configuration files will be loaded from the current working directory by default
 but an `IBEJI_HOME` environment variable can be used to change the base configuration directory to a different one:
 
-```
+```bash
 IBEJI_HOME=/etc/ibeji ./invehicle-digital-twin
 ```
 

--- a/core/common/src/utils.rs
+++ b/core/common/src/utils.rs
@@ -13,6 +13,8 @@ use strum_macros::Display;
 use tokio::time::{sleep, Duration};
 use tonic::{Request, Status};
 
+const IBEJI_HOME_VAR_NAME: &str = "IBEJI_HOME";
+
 /// An identifier used when discovering a service through Chariott.
 #[derive(Debug, Deserialize)]
 pub struct ServiceIdentifier {
@@ -41,8 +43,13 @@ pub fn load_settings<T>(config_filename: &str) -> Result<T, ConfigError>
 where
     T: for<'de> serde::Deserialize<'de>,
 {
+    let config_filename_path = match std::env::var(IBEJI_HOME_VAR_NAME) {
+        Ok(s) => format!("{}/{}", s, config_filename),
+        _ => config_filename.to_owned()
+    };
+
     let config =
-        Config::builder().add_source(File::new(config_filename, FileFormat::Yaml)).build()?;
+        Config::builder().add_source(File::new(config_filename_path.as_str(), FileFormat::Yaml)).build()?;
 
     config.try_deserialize()
 }

--- a/core/common/src/utils.rs
+++ b/core/common/src/utils.rs
@@ -45,11 +45,12 @@ where
 {
     let config_filename_path = match std::env::var(IBEJI_HOME_VAR_NAME) {
         Ok(s) => format!("{}/{}", s, config_filename),
-        _ => config_filename.to_owned()
+        _ => config_filename.to_owned(),
     };
 
-    let config =
-        Config::builder().add_source(File::new(config_filename_path.as_str(), FileFormat::Yaml)).build()?;
+    let config = Config::builder()
+        .add_source(File::new(config_filename_path.as_str(), FileFormat::Yaml))
+        .build()?;
 
     config.try_deserialize()
 }

--- a/core/invehicle-digital-twin/src/invehicle_digital_twin_config.rs
+++ b/core/invehicle-digital-twin/src/invehicle_digital_twin_config.rs
@@ -2,8 +2,7 @@
 // Licensed under the MIT license.
 // SPDX-License-Identifier: MIT
 
-use std::env;
-use config::{Config, File, FileFormat};
+use common::utils;
 use serde_derive::Deserialize;
 
 const CONFIG_FILENAME: &str = "invehicle_digital_twin_settings";
@@ -16,15 +15,7 @@ pub struct Settings {
 
 /// Load the settings.
 pub fn load_settings() -> Settings {
-    let config_filename_path = match env::var("IBEJI_HOME") {
-        Ok(s) => format!("{}/{}", s, CONFIG_FILENAME),
-        _ => CONFIG_FILENAME.to_owned()
-    };
-   
-    let config =
-        Config::builder().add_source(File::new(&config_filename_path, FileFormat::Yaml)).build().unwrap();
+    let s = utils::load_settings(CONFIG_FILENAME).unwrap();
 
-    let settings: Settings = config.try_deserialize().unwrap();
-
-    settings
+    s
 }

--- a/core/invehicle-digital-twin/src/invehicle_digital_twin_config.rs
+++ b/core/invehicle-digital-twin/src/invehicle_digital_twin_config.rs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license.
 // SPDX-License-Identifier: MIT
 
+use std::env;
 use config::{Config, File, FileFormat};
 use serde_derive::Deserialize;
 
@@ -15,8 +16,13 @@ pub struct Settings {
 
 /// Load the settings.
 pub fn load_settings() -> Settings {
+    let config_filename_path = match env::var("IBEJI_HOME") {
+        Ok(s) => format!("{}/{}", s, CONFIG_FILENAME),
+        _ => CONFIG_FILENAME.to_owned()
+    };
+   
     let config =
-        Config::builder().add_source(File::new(CONFIG_FILENAME, FileFormat::Yaml)).build().unwrap();
+        Config::builder().add_source(File::new(&config_filename_path, FileFormat::Yaml)).build().unwrap();
 
     let settings: Settings = config.try_deserialize().unwrap();
 

--- a/core/invehicle-digital-twin/src/invehicle_digital_twin_config.rs
+++ b/core/invehicle-digital-twin/src/invehicle_digital_twin_config.rs
@@ -15,7 +15,5 @@ pub struct Settings {
 
 /// Load the settings.
 pub fn load_settings() -> Settings {
-    let settings = utils::load_settings(CONFIG_FILENAME).unwrap();
-
-    settings
+    utils::load_settings(CONFIG_FILENAME).unwrap()
 }

--- a/core/invehicle-digital-twin/src/invehicle_digital_twin_config.rs
+++ b/core/invehicle-digital-twin/src/invehicle_digital_twin_config.rs
@@ -15,7 +15,7 @@ pub struct Settings {
 
 /// Load the settings.
 pub fn load_settings() -> Settings {
-    let s = utils::load_settings(CONFIG_FILENAME).unwrap();
+    let settings = utils::load_settings(CONFIG_FILENAME).unwrap();
 
-    s
+    settings
 }


### PR DESCRIPTION
## Changes

* Adds an optional "IBEJI_HOME" env var support to be used when using the `invehicle-digital-twin` binary

## Verification

Running the binary with and without the env var should return the correct error path:

```
# without (should work as it is)
$ ./target/debug/invehicle-digital-twin 
[2023-10-25T15:13:40Z INFO  invehicle_digital_twin] The In-Vehicle Digital Twin Service has started.
thread 'main' panicked at 'called `Result::unwrap()` on an `Err` value: configuration file "invehicle_digital_twin_settings" not found', core/invehicle-digital-twin/src/invehicle_digital_twin_config.rs:25:98
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace

# using the env var:
$ IBEJI_HOME=/etc/ibeji ./target/debug/invehicle-digital-twin 
[2023-10-25T15:13:53Z INFO  invehicle_digital_twin] The In-Vehicle Digital Twin Service has started.
thread 'main' panicked at 'called `Result::unwrap()` on an `Err` value: configuration file "/etc/ibeji/invehicle_digital_twin_settings" not found', core/invehicle-digital-twin/src/invehicle_digital_twin_config.rs:25:98
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace

```