### PR TITLE
Add containerization for samples w/ container documentation

### DIFF
--- a/.github/workflows/check-spelling.yml
+++ b/.github/workflows/check-spelling.yml
@@ -17,8 +17,10 @@ jobs:
       - name: Check spelling
         run: |
           ./tools/check_spelling.sh ./README.md
+          ./tools/check_spelling.sh ./container/README.md
           ./tools/check_spelling.sh ./core/common/README.md
           ./tools/check_spelling.sh ./dtdl-parser/README.md
           ./tools/check_spelling.sh ./docs/design/README.md
+          ./tools/check_spelling.sh ./samples/container/README.md
           ./tools/check_spelling.sh ./samples/managed_subscribe/README.md
         shell: bash

--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -20,7 +20,7 @@ jobs:
         with:
           submodules: recursive
       - name: Install packages
-        run: sudo apt-get install -y protobuf-compiler libsdl2-dev
+        run: sudo apt-get update && sudo apt-get install -y protobuf-compiler libsdl2-dev
       - name: Install .NET 7.0
         uses: actions/setup-dotnet@v3
         with:
@@ -54,7 +54,7 @@ jobs:
         with:
           submodules: recursive
       - name: Install packages
-        run: sudo apt-get install -y protobuf-compiler libsdl2-dev
+        run: sudo apt-get update && sudo apt-get install -y protobuf-compiler libsdl2-dev
       - name: Install .NET 7.0
         uses: actions/setup-dotnet@v3
         with:

--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -20,7 +20,7 @@ jobs:
         with:
           submodules: recursive
       - name: Install packages
-        run: sudo apt-get update && sudo apt-get install -y protobuf-compiler libsdl2-dev
+        run: sudo apt-get update -y && sudo apt-get install -y protobuf-compiler libsdl2-dev
       - name: Install .NET 7.0
         uses: actions/setup-dotnet@v3
         with:
@@ -54,7 +54,7 @@ jobs:
         with:
           submodules: recursive
       - name: Install packages
-        run: sudo apt-get update && sudo apt-get install -y protobuf-compiler libsdl2-dev
+        run: sudo apt-get update -y && sudo apt-get install -y protobuf-compiler libsdl2-dev
       - name: Install .NET 7.0
         uses: actions/setup-dotnet@v3
         with:

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,8 +2,6 @@
 # Licensed under the MIT license.
 # SPDX-License-Identifier: MIT
 
-# syntax=docker/dockerfile:1
-
 # Comments are provided throughout this file to help you get started.
 # If you need more help, visit the Dockerfile reference guide at
 # https://docs.docker.com/engine/reference/builder/

--- a/Dockerfile.integrated
+++ b/Dockerfile.integrated
@@ -2,8 +2,6 @@
 # Licensed under the MIT license.
 # SPDX-License-Identifier: MIT
 
-# syntax=docker/dockerfile:1
-
 # Comments are provided throughout this file to help you get started.
 # If you need more help, visit the Dockerfile reference guide at
 # https://docs.docker.com/engine/reference/builder/

--- a/Dockerfile.integrated
+++ b/Dockerfile.integrated
@@ -63,13 +63,13 @@ USER appuser
 WORKDIR /sdv
 
 # Set home environment variable.
-ENV IBEJI_HOME=/sdv
+ENV IBEJI_HOME=/sdv/config
 
 # Copy the executable from the "build" stage.
 COPY --from=build /sdv/service /sdv/
 
 # Copy configuration for service.
-COPY --from=build /sdv/container/config/integrated/ /sdv/
+COPY --from=build /sdv/container/config/integrated/ /sdv/config
 
 # Expose the port that the application listens on.
 EXPOSE 5010

--- a/README.md
+++ b/README.md
@@ -75,7 +75,8 @@ sudo apt install -y protobuf-compiler
 
 ### <a name="install-sdl2-library">Install SDL2 library</a>
 
-You will need to install the libsdl2-dev library. This can be done by executing:
+You will need to install the libsdl2-dev library. This is used by the streaming sample to view
+images. Install the libsdl2-dev library by executing:
 
 ```shell
 sudo apt install -y libsdl2-dev

--- a/README.md
+++ b/README.md
@@ -299,82 +299,9 @@ rather than having it statically provided in their respective config file, then 
 
 ## <a name="running-in-a-container">Running in a Container</a>
 
-Below are the steps for running the service in a container. Note that the configuration files used
-by the containerized service are cloned from [container/config](./container/config/) defined in the
-project's root.
+To run the In-Vehicle Digital Twin Service in a container, please refer to [Ibeji Containerization](./container/README.md).
 
-### <a name="dockerfile">Dockerfile</a>
-
-There are currently two dockerfiles provided in the root directory of the project that can be built:
-
-- Dockerfile - A standalone version of the In-Vehicle Digital Twin Service
-- Dockerfile.integrated - A version of the In-Vehicle Digital Twin Service that communicates with
-the [Chariott Service](https://github.com/eclipse-chariott/chariott) and the
-[Agemo Service](https://github.com/eclipse-chariott/Agemo).
-
-### <a name="docker">Docker</a>
-
-<b>Prerequisites</b>
-
-[Install Docker](https://docs.docker.com/engine/install/)
-
-<b>Running in Docker</b>
-
-To run the service in a Docker container:
-
-1. Run the following command in the project's root directory to build the docker container from the
-Dockerfile:
-
-    ```shell
-    docker build -t invehicle_digital_twin -f Dockerfile .
-    ```
-
-1. Once the container has been built, start the container in interactive mode with the following
-command in the project's root directory:
-
-    ```shell
-    docker run --name invehicle_digital_twin -p 5010:5010 --env-file=./container/config/docker.env --add-host=host.docker.internal:host-gateway -it --rm invehicle_digital_twin
-    ```
-
-1. To detach from the container, enter:
-
-    <kbd>Ctrl</kbd> + <kbd>p</kbd>, <kbd>Ctrl</kbd> + <kbd>q</kbd>
-
-1. To stop the container, enter:
-
-    ```shell
-    docker stop invehicle_digital_twin
-    ```
-
-### <a name="podman">Podman</a>
-
-<b>Prerequisites</b>
-
-[Install Podman](https://podman.io/docs/installation)
-
-<b>Running in Podman</b>
-
-To run the service in a Podman container:
-
-1. Run the following command in the project's root directory to build the podman container from the
-Dockerfile:
-
-    ```shell
-    podman build -t invehicle_digital_twin:latest -f Dockerfile .
-    ```
-
-1. Once the container has been built, start the container with the following command in the
-project's root directory:
-
-    ```shell
-    podman run -p 5010:5010 --env-file=./container/config/podman.env --network=slirp4netns:allow_host_loopback=true localhost/invehicle_digital_twin
-    ```
-
-1. To stop the container, run:
-
-    ```shell
-    podman ps -f ancestor=localhost/invehicle_digital_twin:latest --format="{{.Names}}" | xargs podman stop
-    ```
+To run the samples in a container, please refer to [Samples Containerization](./samples/container/README.md).
 
 ## <a name="trademarks">Trademarks</a>
 

--- a/README.md
+++ b/README.md
@@ -20,9 +20,6 @@
   - [Streaming Sample](#streaming-sample)
   - [Using Chariott](#using-chariott)
 - [Running in a Container](#running-in-a-container)
-  - [Dockerfile](#dockerfile)
-  - [Docker](#docker)
-  - [Podman](#podman)
 - [Trademarks](#trademarks)
 
 ## <a name="introduction">Introduction</a>

--- a/container/.accepted_words.txt
+++ b/container/.accepted_words.txt
@@ -10,6 +10,7 @@ Chariott's
 chariott
 com
 config
+containerize
 containerized
 Containerization
 Ctrl
@@ -20,6 +21,7 @@ Dockerfile
 dockerfile
 dockerfiles
 dotnet
+dst
 dt
 dtdl
 DTDL
@@ -67,12 +69,15 @@ ps
 repo
 Repo
 rm
+ro
 rustup
 sdk
 sdl
 SDL
+sdv
 slirp
 snapd
+src
 standalone
 sudo
 timothee

--- a/container/README.md
+++ b/container/README.md
@@ -57,10 +57,11 @@ command in the project's root directory:
 Follow the steps in [Running in Docker](#running-in-docker) to build the container.
 
 1. To run the container with overridden configuration, create your config file and set an
-environment variable called IBEJI_HOME to the path to the config file:
+environment variable called IBEJI_HOME to the absolute path of the directory containing the
+config file:
 
     ```shell
-    export IBEJI_HOME={path to directory containing config file}
+    export IBEJI_HOME={absolute path of the directory containing the config file}
     ```
 
 1. Then run the container with the following command:
@@ -104,10 +105,11 @@ project's root directory:
 Follow the steps in [Running in Podman](#running-in-podman) to build the container.
 
 1. To run the container with overridden configuration, create your config file and set an
-environment variable called IBEJI_HOME to the path to the config file:
+environment variable called IBEJI_HOME to the absolute path of the directory containing the
+config file:
 
     ```shell
-    export IBEJI_HOME={path to directory containing config file}
+    export IBEJI_HOME={absolute path of the directory containing the config file}
     ```
 
 1. Then run the container with the following command:

--- a/container/README.md
+++ b/container/README.md
@@ -6,7 +6,7 @@ a container please refer to [Samples Containerization](../samples/container/READ
 ## Running the In-Vehicle Digital Twin Service in a Container
 
 Below are the steps for running the service in a container. Note that the configuration files used
-by the containerized service are cloned from [container/config](./container/config/) defined in the
+by the containerized service are cloned from [/container/config](./config/) defined in the
 project's root.
 
 ### Dockerfile

--- a/container/README.md
+++ b/container/README.md
@@ -1,0 +1,117 @@
+# Ibeji Containerization
+
+This document covers how to containerize the In-Vehicle Digital Twin Service. To run the samples as
+a container please refer to [Samples Containerization](../samples/container/README.md).
+
+## Running the In-Vehicle Digital Twin Service in a Container
+
+Below are the steps for running the service in a container. Note that the configuration files used
+by the containerized service are cloned from [container/config](./container/config/) defined in the
+project's root.
+
+### Dockerfile
+
+There are currently two dockerfiles provided in the root directory of the project that can be built:
+
+- Dockerfile - A standalone version of the In-Vehicle Digital Twin Service
+- Dockerfile.integrated - A version of the In-Vehicle Digital Twin Service that communicates with
+the [Chariott Service](https://github.com/eclipse-chariott/chariott) and the
+[Agemo Service](https://github.com/eclipse-chariott/Agemo).
+
+### Docker
+
+#### Prerequisites
+
+[Install Docker](https://docs.docker.com/engine/install/)
+
+#### Running in Docker
+
+To run the service in a Docker container:
+
+1. Run the following command in the project's root directory to build the docker container from the
+Dockerfile:
+
+    ```shell
+    docker build -t invehicle_digital_twin -f Dockerfile .
+    ```
+
+1. Once the container has been built, start the container in interactive mode with the following
+command in the project's root directory:
+
+    ```shell
+    docker run --name invehicle_digital_twin -p 5010:5010 --env-file=./container/config/docker.env --add-host=host.docker.internal:host-gateway -it --rm invehicle_digital_twin
+    ```
+
+1. To detach from the container, enter:
+
+    <kbd>Ctrl</kbd> + <kbd>p</kbd>, <kbd>Ctrl</kbd> + <kbd>q</kbd>
+
+1. To stop the container, enter:
+
+    ```shell
+    docker stop invehicle_digital_twin
+    ```
+
+#### Running in Docker with overridden configuration
+
+Follow the steps in [Running in Docker](#running-in-docker) to build the container.
+
+1. To run the container with overridden configuration, create your config file and set an
+environment variable called IBEJI_HOME to the path to the config file:
+
+    ```shell
+    export IBEJI_HOME={path to directory containing config file}
+    ```
+
+1. Then run the container with the following command:
+
+    ```shell
+    docker run -v ${IBEJI_HOME}:/sdv/config --name invehicle_digital_twin -p 5010:5010 --env-file=./container/config/docker.env --add-host=host.docker.internal:host-gateway -it --rm invehicle_digital_twin
+    ```
+
+### Podman
+
+#### Prerequisites
+
+[Install Podman](https://podman.io/docs/installation)
+
+#### Running in Podman
+
+To run the service in a Podman container:
+
+1. Run the following command in the project's root directory to build the podman container from the
+Dockerfile:
+
+    ```shell
+    podman build -t invehicle_digital_twin:latest -f Dockerfile .
+    ```
+
+1. Once the container has been built, start the container with the following command in the
+project's root directory:
+
+    ```shell
+    podman run -p 5010:5010 --env-file=./container/config/podman.env --network=slirp4netns:allow_host_loopback=true localhost/invehicle_digital_twin
+    ```
+
+1. To stop the container, run:
+
+    ```shell
+    podman ps -f ancestor=localhost/invehicle_digital_twin:latest --format="{{.Names}}" | xargs podman stop
+    ```
+
+#### Running in Podman with overridden configuration
+
+Follow the steps in [Running in Podman](#running-in-podman) to build the container.
+
+1. To run the container with overridden configuration, create your config file and set an
+environment variable called IBEJI_HOME to the path to the config file:
+
+    ```shell
+    export IBEJI_HOME={path to directory containing config file}
+    ```
+
+1. Then run the container with the following command:
+
+    ```shell
+    podman run --mount=type=bind,src=${IBEJI_HOME},dst=/sdv/config,ro=true -p 5010:5010 --env-file=./container/config/podman.env --network=slirp4netns:allow_host_loopback=true localhost/invehicle_digital_twin:latest
+    ```

--- a/samples/Dockerfile.consumer
+++ b/samples/Dockerfile.consumer
@@ -2,8 +2,6 @@
 # Licensed under the MIT license.
 # SPDX-License-Identifier: MIT
 
-# syntax=docker/dockerfile:1
-
 # Comments are provided throughout this file to help you get started.
 # If you need more help, visit the Dockerfile reference guide at
 # https://docs.docker.com/engine/reference/builder/

--- a/samples/Dockerfile.consumer
+++ b/samples/Dockerfile.consumer
@@ -13,13 +13,18 @@
 
 ARG RUST_VERSION=1.72.1
 FROM docker.io/library/rust:${RUST_VERSION}-slim-bullseye AS build
-ARG APP_NAME=invehicle-digital-twin
+ARG APP_NAME=property-consumer
 WORKDIR /sdv
 
 COPY ./ .
 
 # Add Build dependencies.
-RUN apt update && apt upgrade -y && apt install -y protobuf-compiler
+RUN apt update && apt upgrade -y && apt install -y \
+    cmake \
+    libsdl2-dev \
+    libssl-dev \
+    pkg-config \
+    protobuf-compiler
 
 # Check that APP_NAME argument is valid.
 RUN sanitized=$(echo "${APP_NAME}" | tr -dc '^[a-zA-Z_0-9-]+$'); \
@@ -29,7 +34,7 @@ RUN sanitized=$(echo "${APP_NAME}" | tr -dc '^[a-zA-Z_0-9-]+$'); \
 }
 
 # Build the application with the 'containerize' feature.
-RUN cargo build --release -p "${APP_NAME}" --features "containerize"
+RUN cargo build --release --bin "${APP_NAME}" --features "containerize"
 
 # Copy the built application to working directory.
 RUN cp ./target/release/"${APP_NAME}" /sdv/service
@@ -46,6 +51,8 @@ RUN cp ./target/release/"${APP_NAME}" /sdv/service
 # reproducability is important, consider using a digest
 # (e.g., debian@sha256:ac707220fbd7b67fc19b112cee8170b41a9e97f703f588b2cdbbcdcecdd8af57).
 FROM docker.io/library/debian:bullseye-slim AS final
+
+RUN apt update && apt upgrade -y && apt install -y libsdl2-dev
 
 # Create a non-privileged user that the app will run under.
 # See https://docs.docker.com/develop/develop-images/dockerfile_best-practices/#user
@@ -69,10 +76,10 @@ ENV IBEJI_HOME=/sdv/config
 COPY --from=build /sdv/service /sdv/
 
 # Copy configuration for service.
-COPY --from=build /sdv/container/config/standalone/ /sdv/config
+COPY --from=build /sdv/samples/container/config/consumer/ /sdv/config
 
 # Expose the port that the application listens on.
-EXPOSE 5010
+EXPOSE 6010
 
 # What the container should run when it is started.
 CMD ["/sdv/service"]

--- a/samples/Dockerfile.provider
+++ b/samples/Dockerfile.provider
@@ -2,8 +2,6 @@
 # Licensed under the MIT license.
 # SPDX-License-Identifier: MIT
 
-# syntax=docker/dockerfile:1
-
 # Comments are provided throughout this file to help you get started.
 # If you need more help, visit the Dockerfile reference guide at
 # https://docs.docker.com/engine/reference/builder/

--- a/samples/Dockerfile.provider
+++ b/samples/Dockerfile.provider
@@ -13,13 +13,18 @@
 
 ARG RUST_VERSION=1.72.1
 FROM docker.io/library/rust:${RUST_VERSION}-slim-bullseye AS build
-ARG APP_NAME=invehicle-digital-twin
+ARG APP_NAME=property-provider
 WORKDIR /sdv
 
 COPY ./ .
 
 # Add Build dependencies.
-RUN apt update && apt upgrade -y && apt install -y protobuf-compiler
+RUN apt update && apt upgrade -y && apt install -y \
+    cmake \
+    libsdl2-dev \
+    libssl-dev \
+    pkg-config \
+    protobuf-compiler
 
 # Check that APP_NAME argument is valid.
 RUN sanitized=$(echo "${APP_NAME}" | tr -dc '^[a-zA-Z_0-9-]+$'); \
@@ -29,7 +34,7 @@ RUN sanitized=$(echo "${APP_NAME}" | tr -dc '^[a-zA-Z_0-9-]+$'); \
 }
 
 # Build the application with the 'containerize' feature.
-RUN cargo build --release -p "${APP_NAME}" --features "containerize"
+RUN cargo build --release --bin "${APP_NAME}" --features "containerize"
 
 # Copy the built application to working directory.
 RUN cp ./target/release/"${APP_NAME}" /sdv/service
@@ -46,6 +51,8 @@ RUN cp ./target/release/"${APP_NAME}" /sdv/service
 # reproducability is important, consider using a digest
 # (e.g., debian@sha256:ac707220fbd7b67fc19b112cee8170b41a9e97f703f588b2cdbbcdcecdd8af57).
 FROM docker.io/library/debian:bullseye-slim AS final
+
+RUN apt update && apt upgrade -y && apt install -y libsdl2-dev
 
 # Create a non-privileged user that the app will run under.
 # See https://docs.docker.com/develop/develop-images/dockerfile_best-practices/#user
@@ -69,10 +76,10 @@ ENV IBEJI_HOME=/sdv/config
 COPY --from=build /sdv/service /sdv/
 
 # Copy configuration for service.
-COPY --from=build /sdv/container/config/standalone/ /sdv/config
+COPY --from=build /sdv/samples/container/config/provider/ /sdv/config
 
 # Expose the port that the application listens on.
-EXPOSE 5010
+EXPOSE 4010
 
 # What the container should run when it is started.
 CMD ["/sdv/service"]

--- a/samples/common/Cargo.toml
+++ b/samples/common/Cargo.toml
@@ -19,3 +19,6 @@ serde_derive = { workspace = true }
 tokio = { workspace = true }
 tonic = { workspace = true }
 yaml-rust = { workspace = true }
+
+[features]
+containerize = []

--- a/samples/common/src/consumer_config.rs
+++ b/samples/common/src/consumer_config.rs
@@ -2,7 +2,8 @@
 // Licensed under the MIT license.
 // SPDX-License-Identifier: MIT
 
-use config::{Config, File, FileFormat};
+use crate::utils;
+
 use serde_derive::Deserialize;
 
 const CONFIG_FILENAME: &str = "consumer_settings";
@@ -16,10 +17,5 @@ pub struct Settings {
 
 /// Load the settings.
 pub fn load_settings() -> Settings {
-    let config =
-        Config::builder().add_source(File::new(CONFIG_FILENAME, FileFormat::Yaml)).build().unwrap();
-
-    let settings: Settings = config.try_deserialize().unwrap();
-
-    settings
+    utils::load_settings(CONFIG_FILENAME).unwrap()
 }

--- a/samples/common/src/provider_config.rs
+++ b/samples/common/src/provider_config.rs
@@ -2,7 +2,8 @@
 // Licensed under the MIT license.
 // SPDX-License-Identifier: MIT
 
-use config::{Config, File, FileFormat};
+use crate::utils;
+
 use serde_derive::Deserialize;
 
 const CONFIG_FILENAME: &str = "provider_settings";
@@ -16,10 +17,5 @@ pub struct Settings {
 
 /// Load the settings.
 pub fn load_settings() -> Settings {
-    let config =
-        Config::builder().add_source(File::new(CONFIG_FILENAME, FileFormat::Yaml)).build().unwrap();
-
-    let settings: Settings = config.try_deserialize().unwrap();
-
-    settings
+    utils::load_settings(CONFIG_FILENAME).unwrap()
 }

--- a/samples/common/src/utils.rs
+++ b/samples/common/src/utils.rs
@@ -238,8 +238,8 @@ pub async fn retrieve_invehicle_digital_twin_uri(
     })
 }
 
-/// If feature 'containerize' is set, will modify a localhost uri to point to container's localhost
-/// DNS alias. Otherwise, returns the uri as a String.
+/// If the 'containerize' feature is set, this function will modify the localhost URI to point to
+/// the container's localhost DNS alias. Otherwise, returns the URI as a string.
 ///
 /// # Arguments
 /// * `uri` - The uri to potentially modify.

--- a/samples/common/src/utils.rs
+++ b/samples/common/src/utils.rs
@@ -135,9 +135,8 @@ pub async fn discover_digital_twin_provider_using_ibeji(
                 result.uri
             );
 
-            result.uri = get_uri(&result.uri).map_err(|err| {
-                format!("Failed to get provider URI due to error: {err}").to_string()
-            })?;
+            result.uri = get_uri(&result.uri)
+                .map_err(|err| format!("Failed to get provider URI due to error: {err}"))?;
 
             Ok(result)
         }
@@ -236,7 +235,6 @@ pub async fn retrieve_invehicle_digital_twin_uri(
 
     get_uri(&result).map_err(|err| {
         format!("Failed to retrieve the in-vehicle digital twin service's URI due to error: {err}")
-            .to_string()
     })
 }
 

--- a/samples/common/src/utils.rs
+++ b/samples/common/src/utils.rs
@@ -135,7 +135,9 @@ pub async fn discover_digital_twin_provider_using_ibeji(
                 result.uri
             );
 
-            result.uri = get_uri(&result.uri).map_err(|err| format!("Failed to get provider URI due to error: {err}").to_string())?;
+            result.uri = get_uri(&result.uri).map_err(|err| {
+                format!("Failed to get provider URI due to error: {err}").to_string()
+            })?;
 
             Ok(result)
         }
@@ -162,9 +164,8 @@ pub async fn discover_service_using_chariott(
 ) -> Result<String, Status> {
     let uri = get_uri(chariott_uri)?;
 
-    let mut client = ServiceRegistryClient::connect(uri)
-        .await
-        .map_err(|e| Status::internal(e.to_string()))?;
+    let mut client =
+        ServiceRegistryClient::connect(uri).await.map_err(|e| Status::internal(e.to_string()))?;
 
     let request = Request::new(DiscoverRequest {
         namespace: namespace.to_string(),
@@ -233,7 +234,10 @@ pub async fn retrieve_invehicle_digital_twin_uri(
         }
     };
 
-    get_uri(&result).map_err(|err| format!("Failed to retrieve the in-vehicle digital twin service's URI due to error: {err}").to_string())
+    get_uri(&result).map_err(|err| {
+        format!("Failed to retrieve the in-vehicle digital twin service's URI due to error: {err}")
+            .to_string()
+    })
 }
 
 /// If feature 'containerize' is set, will modify a localhost uri to point to container's localhost

--- a/samples/common/src/utils.rs
+++ b/samples/common/src/utils.rs
@@ -4,6 +4,7 @@
 
 use crate::constants;
 
+use config::{Config, ConfigError, File, FileFormat};
 use constants::chariott::{
     INVEHICLE_DIGITAL_TWIN_SERVICE_COMMUNICATION_KIND,
     INVEHICLE_DIGITAL_TWIN_SERVICE_COMMUNICATION_REFERENCE, INVEHICLE_DIGITAL_TWIN_SERVICE_NAME,
@@ -17,6 +18,28 @@ use samples_protobuf_data_access::invehicle_digital_twin::v1::{EndpointInfo, Fin
 use std::future::Future;
 use tokio::time::{sleep, Duration};
 use tonic::{Code, Request, Status};
+
+const IBEJI_HOME_VAR_NAME: &str = "IBEJI_HOME";
+
+/// Load the settings.
+///
+/// # Arguments
+/// * `config_filename` - Name of the config file to load settings from.
+pub fn load_settings<T>(config_filename: &str) -> Result<T, ConfigError>
+where
+    T: for<'de> serde::Deserialize<'de>,
+{
+    let config_filename_path = match std::env::var(IBEJI_HOME_VAR_NAME) {
+        Ok(s) => format!("{}/{}", s, config_filename),
+        _ => config_filename.to_owned(),
+    };
+
+    let config = Config::builder()
+        .add_source(File::new(config_filename_path.as_str(), FileFormat::Yaml))
+        .build()?;
+
+    config.try_deserialize()
+}
 
 /// Is the provided subset a subset of the provided superset?
 ///
@@ -106,11 +129,14 @@ pub async fn discover_digital_twin_provider_using_ibeji(
         })
         .cloned()
     {
-        Some(result) => {
+        Some(mut result) => {
             info!(
                 "Found a matching endpoint for entity id {entity_id} that has URI {}",
                 result.uri
             );
+
+            result.uri = get_uri(&result.uri).map_err(|err| format!("Failed to get provider URI due to error: {err}").to_string())?;
+
             Ok(result)
         }
         None => Err("Did not find an endpoint that met our requirements".to_string()),
@@ -134,7 +160,9 @@ pub async fn discover_service_using_chariott(
     communication_kind: &str,
     communication_reference: &str,
 ) -> Result<String, Status> {
-    let mut client = ServiceRegistryClient::connect(chariott_uri.to_string())
+    let uri = get_uri(chariott_uri)?;
+
+    let mut client = ServiceRegistryClient::connect(uri)
         .await
         .map_err(|e| Status::internal(e.to_string()))?;
 
@@ -205,7 +233,37 @@ pub async fn retrieve_invehicle_digital_twin_uri(
         }
     };
 
-    Ok(result)
+    get_uri(&result).map_err(|err| format!("Failed to retrieve the in-vehicle digital twin service's URI due to error: {err}").to_string())
+}
+
+/// If feature 'containerize' is set, will modify a localhost uri to point to container's localhost
+/// DNS alias. Otherwise, returns the uri as a String.
+///
+/// # Arguments
+/// * `uri` - The uri to potentially modify.
+pub fn get_uri(uri: &str) -> Result<String, Status> {
+    #[cfg(feature = "containerize")]
+    let uri = {
+        // Container env variable names.
+        let host_gateway_env_var: &str = "HOST_GATEWAY";
+        let host_alias_env_var: &str = "LOCALHOST_ALIAS";
+
+        // Return an error if container env variables are not set.
+        let host_gateway = std::env::var(host_gateway_env_var).map_err(|err| {
+            Status::failed_precondition(format!(
+                "Unable to get environment var '{host_gateway_env_var}' with error: {err}"
+            ))
+        })?;
+        let host_alias = std::env::var(host_alias_env_var).map_err(|err| {
+            Status::failed_precondition(format!(
+                "Unable to get environment var '{host_alias_env_var}' with error: {err}"
+            ))
+        })?;
+
+        uri.replace(&host_alias, &host_gateway)
+    };
+
+    Ok(uri.to_string())
 }
 
 #[cfg(test)]

--- a/samples/container/.accepted_words.txt
+++ b/samples/container/.accepted_words.txt
@@ -1,5 +1,7 @@
 Agemo
 agemo
+APP
+arg
 br
 build
 cargo
@@ -10,6 +12,7 @@ Chariott's
 chariott
 com
 config
+containerize
 containerized
 Containerization
 Ctrl
@@ -20,6 +23,7 @@ Dockerfile
 dockerfile
 dockerfiles
 dotnet
+dst
 dt
 dtdl
 DTDL
@@ -67,12 +71,15 @@ ps
 repo
 Repo
 rm
+ro
 rustup
 sdk
 sdl
 SDL
+sdv
 slirp
 snapd
+src
 standalone
 sudo
 timothee

--- a/samples/container/README.md
+++ b/samples/container/README.md
@@ -18,7 +18,7 @@ Provider containers utilize the dockerfile [Dockerfile.provider](../Dockerfile.p
 
 By default, the sample provider built in the Dockerfile is the
 [property-provider](./samples/property/provider/). To change the provider the container builds, use
-the following command:
+the following argument:
 
     <b>Docker</b>
 
@@ -89,7 +89,7 @@ Consumer containers utilize the dockerfile [Dockerfile.consumer](../Dockerfile.c
 
 By default, the sample consumer built in the Dockerfile is the
 [property-consumer](./samples/property/consumer/). To change the consumer the container builds, use
-the following command:
+the following argument:
 
     <b>Docker</b>
 

--- a/samples/container/README.md
+++ b/samples/container/README.md
@@ -1,0 +1,153 @@
+# Samples Containerization
+
+This document covers how to containerize the samples for Ibeji. To run the in-vehicle digital twin
+service as a container or to get more in depth instruction for building and running a container
+please refer to [Ibeji Containerization](../../container/README.md).
+
+## Running the Samples in a Container
+
+Below are the steps for running the sample providers and consumers in a container. Note that the
+configuration files used by the containerized sample are cloned from
+[/samples/container/config](./samples/container/config/) defined in the project's root.
+
+### Provider
+
+Provider containers utilize the dockerfile [Dockerfile.provider](../Dockerfile.provider).
+
+#### Build
+
+By default, the sample provider built in the Dockerfile is the
+[property-provider](./samples/property/provider/). To change the provider the container builds, use
+the following command:
+
+    <b>Docker</b>
+
+    ```shell
+    --build-arg APP_NAME={name of the provider}
+    ```
+
+    For example:
+
+    ```shell
+    docker build -t provider -f ./samples/Dockerfile.provider . --build-arg APP_NAME=managed-subscribe-provider
+    ```
+
+    <b>Podman</b>
+
+    ```shell
+    --build-arg=APP_NAME={name of the provider}
+    ```
+
+    For example:
+
+    ```shell
+    podman build -t provider:latest -f ./samples/Dockerfile.provider . --build-arg=APP_NAME=managed-subscribe-provider
+    ```
+
+#### Run
+
+If you selected a different provider than the default provider built in the dockerfile, you may
+need to override the configuration file [provider_settings.yaml](./config/provider/provider_settings.yaml).
+To override the configuration of a provider container, follow the below steps after you have built
+the container:
+
+    <b>Docker</b>
+
+    1. To run the container with overridden configuration, create your config file and set an
+    environment variable called IBEJI_HOME to the path to the config file:
+
+        ```shell
+        export IBEJI_HOME={path to directory containing config file}
+        ```
+
+    1. Then run the container from the project's root with the following command:
+
+        ```shell
+        docker run -v ${IBEJI_HOME}:/sdv/config --name provider -p 5010:5010 --env-file=./samples/container/config/docker.env --add-host=host.docker.internal:host-gateway -it --rm invehicle_digital_twin
+        ```
+
+    <b>Podman</b>
+
+    1. To run the container with overridden configuration, create your config file and set an
+    environment variable called IBEJI_HOME to the path to the config file:
+
+        ```shell
+        export IBEJI_HOME={path to directory containing config file}
+        ```
+
+    1. Then run the container from the project's root with the following command:
+
+        ```shell
+        podman run --mount=type=bind,src=${IBEJI_HOME},dst=/sdv/config,ro=true -p 5010:5010 --env-file=./samples/container/config/podman.env --network=slirp4netns:allow_host_loopback=true localhost/provider:latest
+        ```
+
+### Consumer
+
+Consumer containers utilize the dockerfile [Dockerfile.consumer](../Dockerfile.consumer).
+
+#### Build
+
+By default, the sample consumer built in the Dockerfile is the
+[property-consumer](./samples/property/consumer/). To change the consumer the container builds, use
+the following command:
+
+    <b>Docker</b>
+
+    ```shell
+    --build-arg APP_NAME={name of the consumer}
+    ```
+
+    For example:
+
+    ```shell
+    docker build -t consumer -f ./samples/Dockerfile.consumer . --build-arg APP_NAME=managed-subscribe-consumer
+    ```
+
+    <b>Podman</b>
+
+    ```shell
+    --build-arg=APP_NAME={name of the consumer}
+    ```
+
+    For example:
+
+    ```shell
+    podman build -t consumer:latest -f ./samples/Dockerfile.consumer . --build-arg=APP_NAME=managed-subscribe-consumer
+    ```
+
+#### Run
+
+If you selected a different consumer than the default consumer built in the dockerfile, you may
+need to override the configuration file [consumer_settings.yaml](./config/consumer/consumer_settings.yaml).
+To override the configuration of a consumer container, follow the below steps after you have built
+the container:
+
+    <b>Docker</b>
+
+    1. To run the container with overridden configuration, create your config file and set an
+    environment variable called IBEJI_HOME to the path to the config file:
+
+        ```shell
+        export IBEJI_HOME={path to directory containing config file}
+        ```
+
+    1. Then run the container from the project's root with the following command:
+
+        ```shell
+        docker run -v ${IBEJI_HOME}:/sdv/config --name consumer -p 5010:5010 --env-file=./samples/container/config/docker.env --add-host=host.docker.internal:host-gateway -it --rm invehicle_digital_twin
+        ```
+
+    <b>Podman</b>
+
+    1. To run the container with overridden configuration, create your config file and set an
+    environment variable called IBEJI_HOME to the path to the config file:
+
+        ```shell
+        export IBEJI_HOME={path to directory containing config file}
+        ```
+
+    1. Then run the container from the project's root with the following command:
+
+        ```shell
+        podman run --mount=type=bind,src=${IBEJI_HOME},dst=/sdv/config,ro=true -p 5010:5010 --env-file=./samples/container/config/podman.env --network=slirp4netns:allow_host_loopback=true localhost/consumer:latest
+        ```

--- a/samples/container/README.md
+++ b/samples/container/README.md
@@ -54,10 +54,11 @@ the container:
     <b>Docker</b>
 
     1. To run the container with overridden configuration, create your config file and set an
-    environment variable called IBEJI_HOME to the path to the config file:
+    environment variable called IBEJI_HOME to the absolute path of the directory containing the
+    config file:
 
         ```shell
-        export IBEJI_HOME={path to directory containing config file}
+        export IBEJI_HOME={absolute path of the directory containing the config file}
         ```
 
     1. Then run the container from the project's root with the following command:
@@ -69,10 +70,11 @@ the container:
     <b>Podman</b>
 
     1. To run the container with overridden configuration, create your config file and set an
-    environment variable called IBEJI_HOME to the path to the config file:
+    environment variable called IBEJI_HOME to the absolute path of the directory containing the
+    config file:
 
         ```shell
-        export IBEJI_HOME={path to directory containing config file}
+        export IBEJI_HOME={absolute path of the directory containing the config file}
         ```
 
     1. Then run the container from the project's root with the following command:
@@ -125,10 +127,11 @@ the container:
     <b>Docker</b>
 
     1. To run the container with overridden configuration, create your config file and set an
-    environment variable called IBEJI_HOME to the path to the config file:
+    environment variable called IBEJI_HOME to the absolute path of the directory containing the
+    config file:
 
         ```shell
-        export IBEJI_HOME={path to directory containing config file}
+        export IBEJI_HOME={absolute path of the directory containing the config file}
         ```
 
     1. Then run the container from the project's root with the following command:
@@ -140,10 +143,11 @@ the container:
     <b>Podman</b>
 
     1. To run the container with overridden configuration, create your config file and set an
-    environment variable called IBEJI_HOME to the path to the config file:
+    environment variable called IBEJI_HOME to the absolute path of the directory containing the
+    config file:
 
         ```shell
-        export IBEJI_HOME={path to directory containing config file}
+        export IBEJI_HOME={absolute path of the directory containing the config file}
         ```
 
     1. Then run the container from the project's root with the following command:

--- a/samples/container/README.md
+++ b/samples/container/README.md
@@ -8,7 +8,7 @@ please refer to [Ibeji Containerization](../../container/README.md).
 
 Below are the steps for running the sample providers and consumers in a container. Note that the
 configuration files used by the containerized sample are cloned from
-[/samples/container/config](./samples/container/config/) defined in the project's root.
+[/samples/container/config](./config/) defined in the project's root.
 
 ### Provider
 
@@ -17,7 +17,7 @@ Provider containers utilize the dockerfile [Dockerfile.provider](../Dockerfile.p
 #### Build
 
 By default, the sample provider built in the Dockerfile is the
-[property-provider](./samples/property/provider/). To change the provider the container builds, use
+[property-provider](../property/provider/). To change the provider the container builds, use
 the following argument:
 
     <b>Docker</b>
@@ -88,7 +88,7 @@ Consumer containers utilize the dockerfile [Dockerfile.consumer](../Dockerfile.c
 #### Build
 
 By default, the sample consumer built in the Dockerfile is the
-[property-consumer](./samples/property/consumer/). To change the consumer the container builds, use
+[property-consumer](../property/consumer/). To change the consumer the container builds, use
 the following argument:
 
     <b>Docker</b>

--- a/samples/container/config/consumer/consumer_settings.yaml
+++ b/samples/container/config/consumer/consumer_settings.yaml
@@ -1,0 +1,14 @@
+#
+# Consumer Settings
+#
+
+# The IP address and port number that the consumer listens on for consumer requests.
+# Example: "0.0.0.0:80"
+consumer_authority: "0.0.0.0:6010"
+
+# The URL that the in-vehicle digital twin service listens on for digital twin requests.
+invehicle_digital_twin_uri: "http://0.0.0.0:5010"
+
+# The URL that the Chariott service listens on for requests.
+# If you wish to use Chariott, then uncomment this setting and comment out the invehicle_digital_twin_url setting.
+#chariott_uri: "http://0.0.0.0:50000"

--- a/samples/container/config/consumer/consumer_settings.yaml
+++ b/samples/container/config/consumer/consumer_settings.yaml
@@ -2,13 +2,5 @@
 # Consumer Settings
 #
 
-# The IP address and port number that the consumer listens on for consumer requests.
-# Example: "0.0.0.0:80"
-consumer_authority: "0.0.0.0:6010"
-
 # The URL that the in-vehicle digital twin service listens on for digital twin requests.
 invehicle_digital_twin_uri: "http://0.0.0.0:5010"
-
-# The URL that the Chariott service listens on for requests.
-# If you wish to use Chariott, then uncomment this setting and comment out the invehicle_digital_twin_url setting.
-#chariott_uri: "http://0.0.0.0:50000"

--- a/samples/container/config/consumer/consumer_settings.yaml
+++ b/samples/container/config/consumer/consumer_settings.yaml
@@ -3,4 +3,4 @@
 #
 
 # The URL that the in-vehicle digital twin service listens on for digital twin requests.
-invehicle_digital_twin_uri: "http://0.0.0.0:5010"
+invehicle_digital_twin_uri: "http://0.0.0.0:5010" # DevSkim: ignore DS137138

--- a/samples/container/config/docker.env
+++ b/samples/container/config/docker.env
@@ -1,0 +1,9 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT license.
+# SPDX-License-Identifier: MIT
+
+# DNS name used by the container to communicate with host.
+HOST_GATEWAY=host.docker.internal
+
+# Alias for localhost to be replaced by HOST_GATEWAY if run in a container.
+LOCALHOST_ALIAS=0.0.0.0

--- a/samples/container/config/podman.env
+++ b/samples/container/config/podman.env
@@ -1,0 +1,9 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT license.
+# SPDX-License-Identifier: MIT
+
+# DNS name used by the container to communicate with host.
+HOST_GATEWAY=host.containers.internal
+
+# Alias for localhost to be replaced by HOST_GATEWAY if run in a container.
+LOCALHOST_ALIAS=0.0.0.0

--- a/samples/container/config/provider/provider_settings.yaml
+++ b/samples/container/config/provider/provider_settings.yaml
@@ -8,7 +8,3 @@ provider_authority: "0.0.0.0:1883"
 
 # The URL that the in-vehicle digital twin service listens on for digital twin requests.
 invehicle_digital_twin_uri: "http://0.0.0.0:5010"
-
-# The URL that the Chariott service listens on for requests.
-# If you wish to use Chariott, then uncomment this setting and comment out the invehicle_digital_twin_url setting.
-# chariott_uri: "http://0.0.0.0:50000"

--- a/samples/container/config/provider/provider_settings.yaml
+++ b/samples/container/config/provider/provider_settings.yaml
@@ -1,0 +1,14 @@
+#
+# Provider Settings
+#
+
+# The IP address and port number that the provider listens on for provider requests.
+# Example: "0.0.0.0:80"
+provider_authority: "0.0.0.0:1883"
+
+# The URL that the in-vehicle digital twin service listens on for digital twin requests.
+invehicle_digital_twin_uri: "http://0.0.0.0:5010"
+
+# The URL that the Chariott service listens on for requests.
+# If you wish to use Chariott, then uncomment this setting and comment out the invehicle_digital_twin_url setting.
+# chariott_uri: "http://0.0.0.0:50000"

--- a/samples/container/config/provider/provider_settings.yaml
+++ b/samples/container/config/provider/provider_settings.yaml
@@ -7,4 +7,4 @@
 provider_authority: "0.0.0.0:1883"
 
 # The URL that the in-vehicle digital twin service listens on for digital twin requests.
-invehicle_digital_twin_uri: "http://0.0.0.0:5010"
+invehicle_digital_twin_uri: "http://0.0.0.0:5010" # DevSkim: ignore DS137138

--- a/samples/managed_subscribe/Cargo.toml
+++ b/samples/managed_subscribe/Cargo.toml
@@ -38,3 +38,6 @@ path = "provider/src/main.rs"
 [[bin]]
 name = "managed-subscribe-consumer"
 path = "consumer/src/main.rs"
+
+[features]
+containerize = ["samples-common/containerize"]

--- a/samples/managed_subscribe/consumer/src/main.rs
+++ b/samples/managed_subscribe/consumer/src/main.rs
@@ -11,7 +11,7 @@ use paho_mqtt as mqtt;
 use samples_common::constants::{constraint_type, digital_twin_operation, digital_twin_protocol};
 use samples_common::consumer_config;
 use samples_common::utils::{
-    discover_digital_twin_provider_using_ibeji, retrieve_invehicle_digital_twin_uri,
+    get_uri, discover_digital_twin_provider_using_ibeji, retrieve_invehicle_digital_twin_uri,
 };
 use samples_protobuf_data_access::module::managed_subscribe::v1::managed_subscribe_client::ManagedSubscribeClient;
 use samples_protobuf_data_access::module::managed_subscribe::v1::{
@@ -180,7 +180,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     .await?;
 
     // Deconstruct subscription information.
-    let broker_uri = subscription_info.uri;
+    let broker_uri = get_uri(&subscription_info.uri)?;
     let topic = subscription_info.context;
     info!("The broker URI for the AmbientAirTemperature property's provider is {broker_uri}");
 

--- a/samples/managed_subscribe/consumer/src/main.rs
+++ b/samples/managed_subscribe/consumer/src/main.rs
@@ -11,7 +11,7 @@ use paho_mqtt as mqtt;
 use samples_common::constants::{constraint_type, digital_twin_operation, digital_twin_protocol};
 use samples_common::consumer_config;
 use samples_common::utils::{
-    get_uri, discover_digital_twin_provider_using_ibeji, retrieve_invehicle_digital_twin_uri,
+    discover_digital_twin_provider_using_ibeji, get_uri, retrieve_invehicle_digital_twin_uri,
 };
 use samples_protobuf_data_access::module::managed_subscribe::v1::managed_subscribe_client::ManagedSubscribeClient;
 use samples_protobuf_data_access::module::managed_subscribe::v1::{

--- a/samples/managed_subscribe/provider/src/provider_impl.rs
+++ b/samples/managed_subscribe/provider/src/provider_impl.rs
@@ -16,6 +16,7 @@ use log::{debug, info, warn};
 use paho_mqtt as mqtt;
 use parking_lot::RwLock;
 use samples_common::constants::constraint_type;
+use samples_common::utils;
 use serde_derive::{Deserialize, Serialize};
 use strum_macros::{Display, EnumString};
 use tokio::sync::{mpsc, watch};
@@ -130,7 +131,9 @@ impl ProviderImpl {
         let min_interval_ms = self.min_interval_ms;
 
         // This should not be empty.
-        let subscription_info = payload.subscription_info.unwrap();
+        let mut subscription_info = payload.subscription_info.unwrap();
+
+        subscription_info.uri = utils::get_uri(&subscription_info.uri).unwrap();
 
         // Create stop publish channel.
         let (sender, mut reciever) = mpsc::channel(10);

--- a/samples/property/Cargo.toml
+++ b/samples/property/Cargo.toml
@@ -36,3 +36,6 @@ path = "provider/src/main.rs"
 [[bin]]
 name = "property-consumer"
 path = "consumer/src/main.rs"
+
+[features]
+containerize = ["samples-common/containerize"]

--- a/samples/property/consumer/src/main.rs
+++ b/samples/property/consumer/src/main.rs
@@ -21,7 +21,7 @@ const MQTT_CLIENT_ID: &str = "property-consumer";
 /// # Arguments
 /// * `broker_uri` - The broker URI.
 /// * `topic` - The topic.
-fn receive_ambient_air_tempterature_updates(broker_uri: &str, topic: &str) -> Result<(), String> {
+fn receive_ambient_air_temperature_updates(broker_uri: &str, topic: &str) -> Result<(), String> {
     let create_opts = mqtt::CreateOptionsBuilder::new()
         .server_uri(broker_uri)
         .client_id(MQTT_CLIENT_ID.to_string())
@@ -101,7 +101,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let topic = provider_endpoint_info.context;
     info!("The Topic for the AmbientAirTemperature property's provider is {topic})");
 
-    let _receive_result = receive_ambient_air_tempterature_updates(&broker_uri, &topic)
+    let _receive_result = receive_ambient_air_temperature_updates(&broker_uri, &topic)
         .map_err(|err| Status::internal(format!("{err:?}")));
 
     info!("The Consumer has completed.");

--- a/samples/property/provider/src/main.rs
+++ b/samples/property/provider/src/main.rs
@@ -8,7 +8,9 @@ use log::{debug, info, warn, LevelFilter};
 use paho_mqtt as mqtt;
 use samples_common::constants::{digital_twin_operation, digital_twin_protocol};
 use samples_common::provider_config;
-use samples_common::utils::{get_uri, retrieve_invehicle_digital_twin_uri, retry_async_based_on_status};
+use samples_common::utils::{
+    get_uri, retrieve_invehicle_digital_twin_uri, retry_async_based_on_status,
+};
 use samples_protobuf_data_access::invehicle_digital_twin::v1::invehicle_digital_twin_client::InvehicleDigitalTwinClient;
 use samples_protobuf_data_access::invehicle_digital_twin::v1::{
     EndpointInfo, EntityAccessInfo, RegisterRequest,

--- a/samples/property/provider/src/main.rs
+++ b/samples/property/provider/src/main.rs
@@ -8,7 +8,7 @@ use log::{debug, info, warn, LevelFilter};
 use paho_mqtt as mqtt;
 use samples_common::constants::{digital_twin_operation, digital_twin_protocol};
 use samples_common::provider_config;
-use samples_common::utils::{retrieve_invehicle_digital_twin_uri, retry_async_based_on_status};
+use samples_common::utils::{get_uri, retrieve_invehicle_digital_twin_uri, retry_async_based_on_status};
 use samples_protobuf_data_access::invehicle_digital_twin::v1::invehicle_digital_twin_client::InvehicleDigitalTwinClient;
 use samples_protobuf_data_access::invehicle_digital_twin::v1::{
     EndpointInfo, EntityAccessInfo, RegisterRequest,
@@ -207,7 +207,9 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     })
     .await?;
 
-    start_ambient_air_temperature_data_stream(broker_uri, topic);
+    let stream_uri = get_uri(&broker_uri)?;
+
+    start_ambient_air_temperature_data_stream(stream_uri, topic);
 
     signal::ctrl_c().await.expect("Failed to listen for control-c event");
 


### PR DESCRIPTION
This PR adds the ability to containerize the Ibeji Samples:
- Add dockerfiles for providers and consumers
- Add mechanism to override configuration for all containerized services
- Document how to containerize the samples
- Add README's in the container folders and removed container documentation from main readme
- Add DNS alias code to samples folder
