### PR TITLE
Enable containerized build of Ibeji integrated with Chariott and Agemo

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -11,5 +11,3 @@ target/
 devops/
 docs/
 tools/
-
-Cargo.lock

--- a/Dockerfile.amd64
+++ b/Dockerfile.amd64
@@ -54,7 +54,7 @@ RUN cp ./target/release/"${APP_NAME}" /sdv/service
 # The example below uses the debian bullseye image as the foundation for running the app.
 # By specifying the "bullseye-slim" tag, it will also use whatever happens to be the
 # most recent version of that tag when you build your Dockerfile. If
-# reproducability is important, consider using a digest
+# reproducibility is important, consider using a digest
 # (e.g., debian@sha256:ac707220fbd7b67fc19b112cee8170b41a9e97f703f588b2cdbbcdcecdd8af57).
 FROM docker.io/library/debian:bullseye-slim AS final
 ARG UID

--- a/Dockerfile.arm64
+++ b/Dockerfile.arm64
@@ -58,7 +58,7 @@ RUN cp ./target/aarch64-unknown-linux-gnu/release/"${APP_NAME}" /sdv/service
 # The example below uses the debian bullseye image as the foundation for running the app.
 # By specifying the "bullseye-slim" tag, it will also use whatever happens to be the
 # most recent version of that tag when you build your Dockerfile. If
-# reproducability is important, consider using a digest
+# reproducibility is important, consider using a digest
 # (e.g., debian@sha256:ac707220fbd7b67fc19b112cee8170b41a9e97f703f588b2cdbbcdcecdd8af57).
 FROM docker.io/arm64v8/debian:bullseye-slim AS final
 ARG UID

--- a/Dockerfile_integrated.amd64
+++ b/Dockerfile_integrated.amd64
@@ -1,0 +1,107 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT license.
+# SPDX-License-Identifier: MIT
+
+# Comments are provided throughout this file to help you get started.
+# If you need more help, visit the Dockerfile reference guide at
+# https://docs.docker.com/engine/reference/builder/
+
+################################################################################
+# Create a stage for building the application.
+
+ARG RUST_VERSION=1.72.1
+ARG APP_NAME=invehicle-digital-twin
+ARG FEATURES=managed_subscribe
+ARG UID=10001
+
+FROM docker.io/library/rust:${RUST_VERSION}-slim-bullseye AS build
+ARG APP_NAME
+ARG FEATURES
+WORKDIR /sdv
+
+COPY ./ .
+
+# Check that APP_NAME argument is valid.
+RUN /sdv/container/scripts/argument_sanitizer.sh \
+    --arg-value "${APP_NAME}" \
+    --regex "^[a-zA-Z_0-9-]+$" || \
+    ( echo "Argument sanitizer failed for ARG 'APP_NAME'"; exit 1 )
+
+# Check that FEATURES argument is valid if the argument is not empty.
+# The regex checks if there is one or more features separated by a single space.
+RUN if [ -n "${FEATURES}" ]; then \
+    /sdv/container/scripts/argument_sanitizer.sh \
+    --arg-value "${FEATURES}" \
+    --regex "^[a-zA-Z_0-9-]+(?: [a-zA-Z_0-9-]+)*$" || \
+    ( echo "Argument sanitizer failed for ARG 'FEATURES'"; exit 1 ) \
+    fi
+
+# Add Build dependencies.
+RUN apt update && apt upgrade -y && apt install -y protobuf-compiler
+
+# Build the application (with features if provided).
+RUN cargo build --release -p "${APP_NAME}" --features "${FEATURES}"
+
+# Copy the built application to working directory.
+RUN cp ./target/release/"${APP_NAME}" /sdv/service
+
+################################################################################
+# Create a new stage for running the application that contains the minimal
+# runtime dependencies for the application. This often uses a different base
+# image from the build stage where the necessary files are copied from the build
+# stage.
+#
+# The example below uses the debian bullseye image as the foundation for running the app.
+# By specifying the "bullseye-slim" tag, it will also use whatever happens to be the
+# most recent version of that tag when you build your Dockerfile. If
+# reproducability is important, consider using a digest
+# (e.g., debian@sha256:ac707220fbd7b67fc19b112cee8170b41a9e97f703f588b2cdbbcdcecdd8af57).
+FROM docker.io/library/debian:bullseye-slim AS final
+ARG UID
+
+# Copy container scripts.
+COPY ./container/scripts/*.sh /sdv/scripts/
+
+# Check that UID argument is valid.
+RUN /sdv/scripts/argument_sanitizer.sh \
+    --arg-value "${UID}" \
+    --regex "^[0-9]+$" || \
+    ( echo "Argument sanitizer failed for ARG 'UID'"; exit 1 )
+
+# Create a non-privileged user that the app will run under.
+# See https://docs.docker.com/develop/develop-images/dockerfile_best-practices/#user
+ARG UID=10001
+RUN adduser \
+    --disabled-password \
+    --gecos "" \
+    --home "/nonexistent" \
+    --shell "/sbin/nologin" \
+    --no-create-home \
+    --uid "${UID}" \
+    appuser
+
+# Create and add user ownership to config directory.
+RUN mkdir -p /sdv/config
+RUN chown appuser /sdv/config
+
+# Create mnt directory to copy override configs into.
+RUN mkdir -p /mnt/config
+
+USER appuser
+
+WORKDIR /sdv
+
+# Set home environment variable.
+ENV IBEJI_HOME=/sdv/config
+
+# Copy the executable from the "build" stage.
+COPY --from=build /sdv/service /sdv/
+
+# Copy configuration for service.
+COPY --from=build /sdv/container/config/integrated/ /sdv/config
+
+# Expose the port that the application listens on.
+EXPOSE 5010
+
+# What the container should run when it is started.
+CMD ["/sdv/scripts/container_startup.sh"]

--- a/Dockerfile_integrated.amd64
+++ b/Dockerfile_integrated.amd64
@@ -59,7 +59,7 @@ RUN cp ./target/release/"${APP_NAME}" /sdv/service
 # The example below uses the debian bullseye image as the foundation for running the app.
 # By specifying the "bullseye-slim" tag, it will also use whatever happens to be the
 # most recent version of that tag when you build your Dockerfile. If
-# reproducability is important, consider using a digest
+# reproducibility is important, consider using a digest
 # (e.g., debian@sha256:ac707220fbd7b67fc19b112cee8170b41a9e97f703f588b2cdbbcdcecdd8af57).
 FROM docker.io/library/debian:bullseye-slim AS final
 ARG UID

--- a/Dockerfile_integrated.amd64
+++ b/Dockerfile_integrated.amd64
@@ -6,6 +6,11 @@
 # If you need more help, visit the Dockerfile reference guide at
 # https://docs.docker.com/engine/reference/builder/
 
+# This Dockerfile builds an "integrated" version of Ibeji. Specifically, it builds
+# Ibeji with the managed_subscribe feature to integrate with Eclipse Agemo and
+# the "integrated" configuration to work with Eclipse Chariott Service Discovery
+# and Agemo managed subscribe.
+
 ################################################################################
 # Create a stage for building the application.
 

--- a/Dockerfile_integrated.amd64
+++ b/Dockerfile_integrated.amd64
@@ -105,7 +105,7 @@ COPY --from=build /sdv/service /sdv/
 # Copy configuration for service.
 COPY --from=build /sdv/container/config/integrated/ /sdv/config
 
-# Expose the port that the application listens on.
+# Expose the port that the in-vehicle digital twin service listens on.
 EXPOSE 5010
 
 # What the container should run when it is started.

--- a/Dockerfile_integrated.arm64
+++ b/Dockerfile_integrated.arm64
@@ -109,7 +109,7 @@ COPY --from=build /sdv/service /sdv/
 # Copy configuration for service.
 COPY --from=build /sdv/container/config/integrated/ /sdv/config
 
-# Expose the port that the application listens on.
+# Expose the port that the in-vehicle digital twin service listens on.
 EXPOSE 5010
 
 # What the container should run when it is started.

--- a/Dockerfile_integrated.arm64
+++ b/Dockerfile_integrated.arm64
@@ -1,0 +1,111 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT license.
+# SPDX-License-Identifier: MIT
+
+# Comments are provided throughout this file to help you get started.
+# If you need more help, visit the Dockerfile reference guide at
+# https://docs.docker.com/engine/reference/builder/
+
+################################################################################
+# Create a stage for building the application.
+
+ARG RUST_VERSION=1.72.1
+ARG APP_NAME=invehicle-digital-twin
+ARG FEATURES=managed_subscribe
+ARG UID=10001
+
+FROM docker.io/library/rust:${RUST_VERSION}-slim-bullseye AS build
+ARG APP_NAME
+ARG FEATURES
+WORKDIR /sdv
+
+COPY ./ .
+
+# Check that APP_NAME argument is valid.
+RUN /sdv/container/scripts/argument_sanitizer.sh \
+    --arg-value "${APP_NAME}" \
+    --regex "^[a-zA-Z_0-9-]+$" || \
+    ( echo "Argument sanitizer failed for ARG 'APP_NAME'"; exit 1 )
+
+# Check that FEATURES argument is valid if the argument is not empty.
+# The regex checks if there is one or more features separated by a single space.
+RUN if [ -n "${FEATURES}" ]; then \
+    /sdv/container/scripts/argument_sanitizer.sh \
+    --arg-value "${FEATURES}" \
+    --regex "^[a-zA-Z_0-9-]+(?: [a-zA-Z_0-9-]+)*$" || \
+    ( echo "Argument sanitizer failed for ARG 'FEATURES'"; exit 1 ) \
+    fi
+
+# Add Build dependencies.
+RUN apt update && apt upgrade -y && apt install -y \
+    protobuf-compiler \
+    gcc-aarch64-linux-gnu
+
+RUN rustup target add aarch64-unknown-linux-gnu
+
+# Build the application (with features if provided).
+RUN cargo build --release --target=aarch64-unknown-linux-gnu -p "${APP_NAME}" --features "${FEATURES}"
+
+# Copy the built application to working directory.
+RUN cp ./target/aarch64-unknown-linux-gnu/release/"${APP_NAME}" /sdv/service
+
+################################################################################
+# Create a new stage for running the application that contains the minimal
+# runtime dependencies for the application. This often uses a different base
+# image from the build stage where the necessary files are copied from the build
+# stage.
+#
+# The example below uses the debian bullseye image as the foundation for running the app.
+# By specifying the "bullseye-slim" tag, it will also use whatever happens to be the
+# most recent version of that tag when you build your Dockerfile. If
+# reproducability is important, consider using a digest
+# (e.g., debian@sha256:ac707220fbd7b67fc19b112cee8170b41a9e97f703f588b2cdbbcdcecdd8af57).
+FROM docker.io/arm64v8/debian:bullseye-slim AS final
+ARG UID
+
+# Copy container scripts.
+COPY ./container/scripts/*.sh /sdv/scripts/
+
+# Check that UID argument is valid.
+RUN /sdv/scripts/argument_sanitizer.sh \
+    --arg-value "${UID}" \
+    --regex "^[0-9]+$" || \
+    ( echo "Argument sanitizer failed for ARG 'UID'"; exit 1 )
+
+# Create a non-privileged user that the app will run under.
+# See https://docs.docker.com/develop/develop-images/dockerfile_best-practices/#user
+ARG UID=10001
+RUN adduser \
+    --disabled-password \
+    --gecos "" \
+    --home "/nonexistent" \
+    --shell "/sbin/nologin" \
+    --no-create-home \
+    --uid "${UID}" \
+    appuser
+
+# Create and add user ownership to config directory.
+RUN mkdir -p /sdv/config
+RUN chown appuser /sdv/config
+
+# Create mnt directory to copy override configs into.
+RUN mkdir -p /mnt/config
+
+USER appuser
+
+WORKDIR /sdv
+
+# Set home environment variable.
+ENV IBEJI_HOME=/sdv/config
+
+# Copy the executable from the "build" stage.
+COPY --from=build /sdv/service /sdv/
+
+# Copy configuration for service.
+COPY --from=build /sdv/container/config/integrated/ /sdv/config
+
+# Expose the port that the application listens on.
+EXPOSE 5010
+
+# What the container should run when it is started.
+CMD ["/sdv/scripts/container_startup.sh"]

--- a/Dockerfile_integrated.arm64
+++ b/Dockerfile_integrated.arm64
@@ -6,6 +6,11 @@
 # If you need more help, visit the Dockerfile reference guide at
 # https://docs.docker.com/engine/reference/builder/
 
+# This Dockerfile builds an "integrated" version of Ibeji. Specifically, it builds
+# Ibeji with the managed_subscribe feature to integrate with Eclipse Agemo and
+# the "integrated" configuration to work with Eclipse Chariott Service Discovery
+# and Agemo managed subscribe.
+
 ################################################################################
 # Create a stage for building the application.
 

--- a/Dockerfile_integrated.arm64
+++ b/Dockerfile_integrated.arm64
@@ -63,7 +63,7 @@ RUN cp ./target/aarch64-unknown-linux-gnu/release/"${APP_NAME}" /sdv/service
 # The example below uses the debian bullseye image as the foundation for running the app.
 # By specifying the "bullseye-slim" tag, it will also use whatever happens to be the
 # most recent version of that tag when you build your Dockerfile. If
-# reproducability is important, consider using a digest
+# reproducibility is important, consider using a digest
 # (e.g., debian@sha256:ac707220fbd7b67fc19b112cee8170b41a9e97f703f588b2cdbbcdcecdd8af57).
 FROM docker.io/arm64v8/debian:bullseye-slim AS final
 ARG UID

--- a/samples/Dockerfile.samples.amd64
+++ b/samples/Dockerfile.samples.amd64
@@ -48,7 +48,7 @@ RUN cp ./target/release/"${APP_NAME}" /sdv/service
 # The example below uses the debian bullseye image as the foundation for running the app.
 # By specifying the "bullseye-slim" tag, it will also use whatever happens to be the
 # most recent version of that tag when you build your Dockerfile. If
-# reproducability is important, consider using a digest
+# reproducibility is important, consider using a digest
 # (e.g., debian@sha256:ac707220fbd7b67fc19b112cee8170b41a9e97f703f588b2cdbbcdcecdd8af57).
 FROM docker.io/library/debian:bullseye-slim AS final
 ARG UID

--- a/samples/Dockerfile.samples.arm64
+++ b/samples/Dockerfile.samples.arm64
@@ -52,7 +52,7 @@ RUN cp ./target/aarch64-unknown-linux-gnu/release/"${APP_NAME}" /sdv/service
 # The example below uses the debian bullseye image as the foundation for running the app.
 # By specifying the "bullseye-slim" tag, it will also use whatever happens to be the
 # most recent version of that tag when you build your Dockerfile. If
-# reproducability is important, consider using a digest
+# reproducibility is important, consider using a digest
 # (e.g., debian@sha256:ac707220fbd7b67fc19b112cee8170b41a9e97f703f588b2cdbbcdcecdd8af57).
 FROM docker.io/arm64v8/debian:bullseye-slim AS final
 ARG UID


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Choose an applicable closing keyword and provide the related issue(s) -->
Closes #102 

## Motivation and Context
Today there are configuration and Dockerfiles in order to build Ibeji in standalone mode. Enable a containerized build of Ibeji integrated with Chariott Service Discovery and managed subscribe using Agemo Pub Sub Service.
This also helps for building scenarios (like the Software Orchestration blueprint) which leverage Ibeji, Chariott, and Agemo together.

## Description

- Add Dockerfile_integrated for both target architectures to containerize Ibeji integrated with Chariott Service Discovery and Agemo Pub Sub Service for the managed subscribe feature
- Remove Cargo.lock from dockerignore. It's not present in the gitignore, and it is recommended to include it to have deterministic builds.