### PR TITLE
Add multi-platform dockerfile for ibeji in integrated mode

### DIFF
--- a/Dockerfile_integrated.multi
+++ b/Dockerfile_integrated.multi
@@ -1,0 +1,131 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT license.
+# SPDX-License-Identifier: MIT
+
+# Comments are provided throughout this file to help you get started.
+# If you need more help, visit the Dockerfile reference guide at
+# https://docs.docker.com/engine/reference/builder/
+
+# This Dockerfile builds an "integrated" version of Ibeji. Specifically, it builds
+# Ibeji with the managed_subscribe feature to integrate with Eclipse Agemo and
+# the "integrated" configuration to work with Eclipse Chariott Service Discovery
+# and Agemo managed subscribe.
+
+################################################################################
+# Create a stage for building the application.
+
+ARG RUST_VERSION=1.72.1
+ARG APP_NAME=invehicle-digital-twin
+ARG FEATURES=managed_subscribe
+ARG UID=10001
+
+FROM --platform=$BUILDPLATFORM docker.io/library/rust:${RUST_VERSION}-slim-bullseye AS build
+
+# Target architecture to cross-compile
+ARG TARGETARCH
+
+ARG APP_NAME
+ARG FEATURES
+WORKDIR /sdv
+
+COPY ./ .
+
+# Check that APP_NAME argument is valid.
+RUN /sdv/container/scripts/argument_sanitizer.sh \
+    --arg-value "${APP_NAME}" \
+    --regex "^[a-zA-Z_0-9-]+$" || \
+    ( echo "Argument sanitizer failed for ARG 'APP_NAME'"; exit 1 )
+
+# Check that TARGETARCH argument is valid.
+RUN /sdv/container/scripts/argument_sanitizer.sh \
+    --arg-value "${TARGETARCH}" \
+    --regex "^[a-zA-Z_0-9-]+$" || \
+    ( echo "Argument sanitizer failed for ARG 'TARGETARCH'"; exit 1 )
+
+# Check that FEATURES argument is valid if the argument is not empty.
+# The regex checks if there is one or more features separated by a single space.
+RUN if [ -n "${FEATURES}" ]; then \
+    /sdv/container/scripts/argument_sanitizer.sh \
+    --arg-value "${FEATURES}" \
+    --regex "^[a-zA-Z_0-9-]+(?: [a-zA-Z_0-9-]+)*$" || \
+    ( echo "Argument sanitizer failed for ARG 'FEATURES'"; exit 1 ) \
+    fi
+
+# Add Build dependencies.
+RUN apt update && apt upgrade -y && apt install -y \
+    protobuf-compiler
+
+# Based on the target architecture, add the appropriate build target and build service.
+RUN if [ "$TARGETARCH" = "amd64" ]; then \
+        CARGOARCH="x86_64-unknown-linux-gnu"; \
+    elif [ "$TARGETARCH" = "arm64" ]; then \
+        apt install -y gcc-aarch64-linux-gnu; \
+        CARGOARCH="aarch64-unknown-linux-gnu"; \
+    else \
+        echo "Unsupported cross-compile architecture"; \
+        exit 1; \
+    fi; \
+        rustup target add ${CARGOARCH}; \
+        cargo build --release --target=${CARGOARCH} -p "${APP_NAME}"  --features "${FEATURES}"; \
+        cp /sdv/target/${CARGOARCH}/release/"${APP_NAME}" /sdv/service
+
+################################################################################
+# Create a new stage for running the application that contains the minimal
+# runtime dependencies for the application. This often uses a different base
+# image from the build stage where the necessary files are copied from the build
+# stage.
+#
+# The example below uses the debian bullseye image as the foundation for running the app.
+# By specifying the "bullseye-slim" tag, it will also use whatever happens to be the
+# most recent version of that tag when you build your Dockerfile. If
+# reproducibility is important, consider using a digest
+# (e.g., debian@sha256:ac707220fbd7b67fc19b112cee8170b41a9e97f703f588b2cdbbcdcecdd8af57).
+FROM --platform=$TARGETPLATFORM docker.io/library/debian:bullseye-slim AS final
+ARG UID
+
+# Copy container scripts.
+COPY ./container/scripts/*.sh /sdv/scripts/
+
+# Check that UID argument is valid.
+RUN /sdv/scripts/argument_sanitizer.sh \
+    --arg-value "${UID}" \
+    --regex "^[0-9]+$" || \
+    ( echo "Argument sanitizer failed for ARG 'UID'"; exit 1 )
+
+# Create a non-privileged user that the app will run under.
+# See https://docs.docker.com/develop/develop-images/dockerfile_best-practices/#user
+ARG UID=10001
+RUN adduser \
+    --disabled-password \
+    --gecos "" \
+    --home "/nonexistent" \
+    --shell "/sbin/nologin" \
+    --no-create-home \
+    --uid "${UID}" \
+    appuser
+
+# Create and add user ownership to config directory.
+RUN mkdir -p /sdv/config
+RUN chown appuser /sdv/config
+
+# Create mnt directory to copy override configs into.
+RUN mkdir -p /mnt/config
+
+USER appuser
+
+WORKDIR /sdv
+
+# Set home environment variable.
+ENV IBEJI_HOME=/sdv/config
+
+# Copy the executable from the "build" stage.
+COPY --from=build /sdv/service /sdv/
+
+# Copy configuration for service.
+COPY --from=build /sdv/container/config/integrated/ /sdv/config
+
+# Expose the port that the in-vehicle digital twin service listens on.
+EXPOSE 5010
+
+# What the container should run when it is started.
+CMD ["/sdv/scripts/container_startup.sh"]


### PR DESCRIPTION
Add a multi-platform dockerfile for Ibeji in-vehicle digital twin service in integrated mode. This can be used to build linux/amd64 and/ or linux/arm64 container images using buildx based on the TARGETARCH